### PR TITLE
Use the release/v1 branch for the PyPA action publishing to PyPI

### DIFF
--- a/{{cookiecutter.repo_name}}/.github/workflows/publish_pypi.yml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/publish_pypi.yml
@@ -20,6 +20,6 @@ jobs:
           python -m build
       - name: Publish distribution to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@v1.8.14
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: {{ '${{ secrets.PYPI_PASSWORD }}' }}


### PR DESCRIPTION
See https://github.com/ome/omero-py/pull/456